### PR TITLE
Añadir enlace final a cada entrada RSS

### DIFF
--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -111,8 +111,7 @@ class FeedManager
             if ($entry->url == '') {
                 $remote_anchor = '';
             } else {
-                $remote_anchor = " (<a href='{$entry->url}' target='_blank'>{$entry->url}</a>)";
-                $item->set('source', $entry->url);
+                $remote_anchor = "\n<a href='{$entry->url}' target='_blank'>Enlace original</a>";
             }
             $item->setContent($entry->getShortDesc() . $remote_anchor);
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -109,11 +109,10 @@ class FeedManager
             $item = new Item();
             $item->setTitle($entry->title);
             if ('' === $entry->url) {
-                $remote_anchor = '';
+                $item->setContent($entry->getShortDesc());
             } else {
-                $remote_anchor = "\n<a href='{$entry->url}' target='_blank'>Enlace original</a>";
+                $item->setContent($entry->getShortDesc()."\n<a href='{$entry->url}' target='_blank'>Enlace original</a>");
             }
-            $item->setContent($entry->getShortDesc().$remote_anchor);
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));
             $item->setLink($link);
             $item->set('comments', $link.'#comments');

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -108,12 +108,12 @@ class FeedManager
 
             $item = new Item();
             $item->setTitle($entry->title);
-            if ($entry->url == '') {
+            if ('' === $entry->url) {
                 $remote_anchor = '';
             } else {
                 $remote_anchor = "\n<a href='{$entry->url}' target='_blank'>Enlace original</a>";
             }
-            $item->setContent($entry->getShortDesc() . $remote_anchor);
+            $item->setContent($entry->getShortDesc().$remote_anchor);
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));
             $item->setLink($link);
             $item->set('comments', $link.'#comments');

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -17,8 +17,6 @@ use FeedIo\Feed;
 use FeedIo\Feed\Item;
 use FeedIo\Feed\Node\Category;
 use FeedIo\FeedInterface;
-use FeedIo\Rule\Link;
-use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -35,7 +33,6 @@ class FeedManager
         private readonly RouterInterface $router,
         private readonly EntryFactory $entryFactory,
         private readonly Security $security,
-        private readonly LoggerInterface $logger,
     ) {
     }
 

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -108,8 +108,9 @@ class FeedManager
 
             $item = new Item();
             $url = $entry->url;
+            $url_anchor = "<a href='$url' target='_blank'>{$url}</a>";
             $item->setTitle($entry->title);
-            $item->setContent($entry->getShortDesc() . "\n" . $url);
+            $item->setContent($entry->getShortDesc() . " ({$url_anchor})");
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));
             $item->setLink($link);
             $item->set('comments', $url);

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -17,6 +17,8 @@ use FeedIo\Feed;
 use FeedIo\Feed\Item;
 use FeedIo\Feed\Node\Category;
 use FeedIo\FeedInterface;
+use FeedIo\Rule\Link;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -33,6 +35,7 @@ class FeedManager
         private readonly RouterInterface $router,
         private readonly EntryFactory $entryFactory,
         private readonly Security $security,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -107,11 +110,12 @@ class FeedManager
                 ]);
 
             $item = new Item();
+            $url = $entry->url;
             $item->setTitle($entry->title);
-            $item->setContent($entry->getShortDesc());
+            $item->setContent($entry->getShortDesc() . "\n" . $url);
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));
             $item->setLink($link);
-            $item->set('comments', $link.'#comments');
+            $item->set('comments', $url);
             $item->setPublicId(IriGenerator::getIriFromResource($entry));
             $item->setAuthor((new Item\Author())->setName($entry->user->username));
 

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -107,13 +107,12 @@ class FeedManager
                 ]);
 
             $item = new Item();
-            $url = $entry->url;
-            $url_anchor = "<a href='$url' target='_blank'>{$url}</a>";
             $item->setTitle($entry->title);
-            $item->setContent($entry->getShortDesc() . " ({$url_anchor})");
+            $item->setContent($entry->getShortDesc() . " (<a href='{$entry->url}' target='_blank'>{$entry->url}</a>)");
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));
             $item->setLink($link);
-            $item->set('comments', $url);
+            $item->set('comments', $link.'#comments');
+            $item->set('source', $entry->url);
             $item->setPublicId(IriGenerator::getIriFromResource($entry));
             $item->setAuthor((new Item\Author())->setName($entry->user->username));
 

--- a/src/Service/FeedManager.php
+++ b/src/Service/FeedManager.php
@@ -108,11 +108,16 @@ class FeedManager
 
             $item = new Item();
             $item->setTitle($entry->title);
-            $item->setContent($entry->getShortDesc() . " (<a href='{$entry->url}' target='_blank'>{$entry->url}</a>)");
+            if ($entry->url == '') {
+                $remote_anchor = '';
+            } else {
+                $remote_anchor = " (<a href='{$entry->url}' target='_blank'>{$entry->url}</a>)";
+                $item->set('source', $entry->url);
+            }
+            $item->setContent($entry->getShortDesc() . $remote_anchor);
             $item->setLastModified(\DateTime::createFromImmutable($entry->createdAt));
             $item->setLink($link);
             $item->set('comments', $link.'#comments');
-            $item->set('source', $entry->url);
             $item->setPublicId(IriGenerator::getIriFromResource($entry));
             $item->setAuthor((new Item\Author())->setName($entry->user->username));
 


### PR DESCRIPTION
Esta PR añade el enlace remoto a cada entrada del feed RSS. Sólo en caso de aquellas publicaciones que tengan enlace a la noticia externa.

El enlace es proporcionado como `<a>` al final de `.item.description`

![image](https://github.com/user-attachments/assets/8f068e3c-674c-4805-91ae-0ae5ad514fb9)

https://github.com/tarddigradeOrg/tarddigrade/issues/31